### PR TITLE
fix: replace arch with uname -m

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -81,7 +81,7 @@ download_release() {
 	version="$1"
 	filename="$2"
 
-	architecture="$(arch)"
+	architecture="$(uname -m)"
 	os=$(get_os)
 	ext=$(get_ext)
 	if [ "$os" == "apple-darwin" ]; then


### PR DESCRIPTION
This:
- [x] replaces `arch` with `uname -m`

Why? `arch` is [no longer included in `coreutils` by default](https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html). This will probably cause some confusion for users of up-to-date distributions, who will see something like

```shell
arch: command not found
```

when trying to use this plugin. `uname -m` does the same thing, so may as well use that :slightly_smiling_face:

Thanks for the plugin!