### PR TITLE
Fix incorrect download path for versions > 0.5.0

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -19,7 +19,10 @@ release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.${ext}"
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
 #  Extract contents of tar.gz file into the download directory
-if [[ "$ASDF_INSTALL_VERSION" < "0.5.0" ]]; then
+major=$(echo "$ASDF_INSTALL_VERSION" | cut -d. -f1)
+minor=$(echo "$ASDF_INSTALL_VERSION" | cut -d. -f2)
+
+if [ "$major" == 0 ] && [ "$minor" -lt 5 ] ; then
 	tar -xvzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
 else
 	tar --strip-components=1 -xvzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -77,7 +77,7 @@ get_ext() {
 }
 
 download_release() {
-	local version filename url
+	local major minor version filename url
 	version="$1"
 	filename="$2"
 
@@ -90,10 +90,13 @@ download_release() {
 		fi
 	fi
 
-	if [[ "$version" < "0.5.0" ]]; then
-		url="$GH_REPO/releases//download/v${version}/$TOOL_NAME-${version}-${architecture}-${os}.${ext}"
+	major=$(echo "$version" | cut -d. -f1)
+	minor=$(echo "$version" | cut -d. -f2)
+
+	if [ "$major" == 0 ] && [ "$minor" -lt 5 ] ; then
+		url="$GH_REPO/releases/download/v${version}/$TOOL_NAME-${version}-${architecture}-${os}.${ext}"
 	else
-		url="$GH_REPO/releases//download/${version}/$TOOL_NAME-${architecture}-${os}.${ext}"
+		url="$GH_REPO/releases/download/${version}/$TOOL_NAME-${architecture}-${os}.${ext}"
 	fi
 
 	echo "* Downloading $TOOL_NAME release $version..."


### PR DESCRIPTION
The following PR fixes issue https://github.com/simhem/asdf-ruff/issues/12.

Before this PR we encountered the following error with recente versions of ruff because the semver comparison in the code was not correct.

```bash
asdf plugin test ruff https://github.com/simhem/asdf-ruff --asdf-tool-version 0.12.11 ruff --version
* Downloading ruff release 0.12.11...
curl: (22) The requested URL returned error: 404
asdf-ruff: Could not download https://github.com/astral-sh/ruff/releases//download/v0.12.11/ruff-0.12.11-x86_64-unknown-linux-gnu.tar.gz
FAILED: install exited with an error
```

Now it correctly works.

```bash
# Still works with old versions of ruff
asdf plugin test ruff https://github.com/bgaillard/asdf-ruff --asdf-plugin-gitref issue-12 --asdf-tool-version 0.4.10 ruff --version
* Downloading ruff release 0.4.10...
ruff
ruff 0.4.10 installation was successful!

# And now also works with new versions
asdf plugin test ruff https://github.com/bgaillard/asdf-ruff --asdf-plugin-gitref issue-12 --asdf-tool-version 0.12.11 ruff --version
* Downloading ruff release 0.12.11...
ruff-x86_64-unknown-linux-gnu/ruff
ruff 0.12.11 installation was successful!
```